### PR TITLE
fix reference keys trong cac tables

### DIFF
--- a/schemas/db.py
+++ b/schemas/db.py
@@ -23,7 +23,7 @@ class Clubs(Base):
     club_name = Column(String, index=True)
     total_player = Column(Integer, index=True)
     nation = Column(String, index=True)
-    manager = Column(Integer, ForeignKey("Users.userid"), index=True)
+    manager = Column(Integer, ForeignKey("users.userid"), index=True)
     club_shortname = Column(String, index=True)
     show = Column(Boolean, index=True)
 
@@ -34,7 +34,7 @@ class Players(Base):
     player_id = Column(Integer, primary_key=True, index=True)
     player_name = Column(String, index=True)
     player_bday = Column(Date, index=True)
-    player_club = Column(Integer, ForeignKey("Clubs.clubid"), index=True)
+    player_club = Column(Integer, ForeignKey("clubs.clubid"), index=True)
     player_pos = Column(String, index=True)
     player_nation = Column(String, index=True)
     js_number = Column(Integer, index=True)


### PR DESCRIPTION
lỗi đánh máy lúc khai báo khóa ngoại trong file schemas/db.py. 
Sửa khai báo khóa ngoại từ "Users.userid" --> "users.userid"